### PR TITLE
Pull command, local source

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Config is provided with a yaml file:
 ```yaml
 prefix: string
 sources:
-  - url: https://github.com/entigolabs/entigo-infralib-release
+  - url: https://github.com/entigolabs/entigo-infralib-release | path
     version: stable | semver
     include: []string
     exclude: []string
@@ -237,7 +237,7 @@ Source version is overwritten by module version. Default version is **stable** w
 
 * prefix - prefix used for AWS/GCloud resources, bucket folders/files and terraform resources, limit 10 characters, overwritten by the prefix flag/env var
 * sources - list of source repositories for Entigo Infralib modules
-  * url - url of the source repository
+  * url - url of the source repository or path to the local directory. Path must start with `./` or `../` Path will set force_version to true and use `local` as the version.
   * version - highest version of Entigo Infralib modules to use
   * include - list of module sources to exclusively include from the source repository
   * exclude - list of module sources to exclude from the source repository

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Executes pipelines which apply the specified Entigo infralib terraform modules. 
     * [Update](#update)
     * [Delete](#delete)
     * [Service Account](#service-account)
+    * [Pull](#pull)
 * [Config](#config)
   * [Auto approval logic](#auto-approval-logic)
   * [Overriding config values](#overriding-config-values)
@@ -174,6 +175,24 @@ Example
 bin/ei-agent service-account --prefix=infralib
 ```
 
+### pull
+
+Pulls agent config yaml and the config folders from the S3/GCloud bucket. Use the `force` flag to overwrite existing local files.
+
+OPTIONS:
+* logging - logging level (debug | info | warn | error) (default: **info**) [$LOGGING]
+* config - config file path and name, only needed when overriding an existing config [$CONFIG]
+* prefix - prefix used when creating cloud resources [$PREFIX]
+* project-id - project id used when creating gcloud resources [$PROJECT_ID]
+* location - location used when creating gcloud resources [$LOCATION]
+* zone - zone used in gcloud run jobs [$ZONE]
+* force - overwrite existing local files, default **false**. **Warning!** Force deletes the `/config` subfolder before writing. [$FORCE]
+
+Example
+```bash
+bin/ei-agent pull --prefix=infralib
+```
+
 ## Config
 
 Config is provided with a yaml file:
@@ -237,7 +256,7 @@ Source version is overwritten by module version. Default version is **stable** w
 
 * prefix - prefix used for AWS/GCloud resources, bucket folders/files and terraform resources, limit 10 characters, overwritten by the prefix flag/env var
 * sources - list of source repositories for Entigo Infralib modules
-  * url - url of the source repository or path to the local directory. Path must start with `./` or `../` Path will set force_version to true and use `local` as the version.
+  * url - url of the source repository or path to the local directory. Path must start with `./` or `../` Path will set force_version to true and use `local` as the version. Path only works with the local pipeline execution type.
   * version - highest version of Entigo Infralib modules to use
   * include - list of module sources to exclusively include from the source repository
   * exclude - list of module sources to exclude from the source repository
@@ -319,4 +338,4 @@ Infralib modules may use `{{ .tmodule.type }}` in their default input files to r
 
 ### Including files in steps
 
-It's possible to include files in steps by adding the files into a `./config/<stepName>/include` subdirectory. File names can't include `main.tf`, `provider.tf` or `backend.conf` as they are reserved for the agent. For ArgoCD, reserved name is `argocd.yaml` and a named file for every module `module-name.yaml`. Files will be copied into the step directory which is used by terraform and ArgoCD as step context.
+It's possible to include files in steps by adding the files into a `./config/<stepName>/include` subdirectory. File names can't include `main.tf`, `provider.tf` or `backend.conf` as they are reserved for the agent. For ArgoCD, reserved name is `argocd.yaml` and named files for every module `module-name.yaml`. Files will be copied into the step directory which is used by terraform and ArgoCD as step context.

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -260,6 +260,7 @@ func (a *awsService) createCloudWatchLogs() (string, string, string, CloudWatch)
 
 func (a *awsService) createIAMRoles(logGroupArn string, s3Arn string, dynamoDBTableArn string) (IAM, string, string) {
 	iam := NewIAM(a.ctx, a.awsConfig, a.accountId)
+	iam.CreateServiceLinkedRole("autoscaling.amazonaws.com")
 	buildRoleArn, buildRoleCreated := a.createBuildRole(iam, logGroupArn, s3Arn, dynamoDBTableArn)
 	pipelineRoleArn, pipelineRoleCreated := a.createPipelineRole(iam, s3Arn)
 

--- a/cli/actions.go
+++ b/cli/actions.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/entigolabs/entigo-infralib-agent/commands/bootstrap"
 	"github.com/entigolabs/entigo-infralib-agent/commands/delete"
+	"github.com/entigolabs/entigo-infralib-agent/commands/pull"
 	agentRun "github.com/entigolabs/entigo-infralib-agent/commands/run"
 	"github.com/entigolabs/entigo-infralib-agent/commands/sa"
 	"github.com/entigolabs/entigo-infralib-agent/commands/update"
@@ -36,6 +37,8 @@ func run(ctx context.Context, cmd common.Command) {
 		delete.Delete(ctx, flags)
 	case common.SACommand:
 		sa.Run(ctx, flags)
+	case common.PullCommand:
+		pull.Run(ctx, flags)
 	default:
 		log.Fatal(&common.PrefixedError{Reason: errors.New("unsupported command")})
 	}

--- a/cli/actions.go
+++ b/cli/actions.go
@@ -26,6 +26,7 @@ func action(cmd common.Command) func(c *cli.Context) error {
 }
 
 func run(ctx context.Context, cmd common.Command) {
+	common.PrintVersion()
 	switch cmd {
 	case common.RunCommand:
 		agentRun.Run(ctx, flags)

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -12,6 +12,7 @@ func cliCommands() []*cli.Command {
 		&bootstrapCommand,
 		&deleteCommand,
 		&SACommand,
+		&pullCommand,
 	}
 }
 
@@ -53,4 +54,12 @@ var SACommand = cli.Command{
 	Usage:   "create a service account",
 	Action:  action(common.SACommand),
 	Flags:   cliFlags(common.SACommand),
+}
+
+var pullCommand = cli.Command{
+	Name:    string(common.PullCommand),
+	Aliases: []string{"pl"},
+	Usage:   "pull agent config yaml and included files",
+	Action:  action(common.PullCommand),
+	Flags:   cliFlags(common.PullCommand),
 }

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -33,6 +33,8 @@ func appendCmdSpecificFlags(baseFlags []cli.Flag, cmd common.Command) []cli.Flag
 	case common.RunCommand:
 		baseFlags = append(baseFlags, &allowParallelFlag, &githubToken, &stepsFlag, &pipelineTypeFlag, &logsPathFlag,
 			&printLogsFlag)
+	case common.PullCommand:
+		baseFlags = append(baseFlags, &forceFlag)
 	}
 	return baseFlags
 }
@@ -190,5 +192,15 @@ var printLogsFlag = cli.BoolFlag{
 	Usage:       "print terraform/helm logs to stdout when using local pipelines",
 	Value:       true,
 	Destination: &flags.Pipeline.PrintLogs,
+	Required:    false,
+}
+
+var forceFlag = cli.BoolFlag{
+	Name:        "force",
+	Aliases:     []string{"f"},
+	EnvVars:     []string{"FORCE"},
+	Usage:       "force",
+	Value:       false,
+	Destination: &flags.Force,
 	Required:    false,
 }

--- a/commands/bootstrap/bootstrap.go
+++ b/commands/bootstrap/bootstrap.go
@@ -11,7 +11,7 @@ import (
 func Bootstrap(ctx context.Context, flags *common.Flags) {
 	provider := service.GetCloudProvider(ctx, flags)
 	resources := provider.SetupResources()
-	config := service.GetConfig(nil, resources.GetCloudPrefix(), flags.Config, resources.GetBucket())
+	config := service.GetBaseConfig(resources.GetCloudPrefix(), flags.Config, resources.GetBucket())
 	if config.AgentVersion == "" {
 		config.AgentVersion = model.LatestImageVersion
 	}

--- a/commands/pull/pull.go
+++ b/commands/pull/pull.go
@@ -1,0 +1,158 @@
+package pull
+
+import (
+	"context"
+	"fmt"
+	"github.com/entigolabs/entigo-infralib-agent/common"
+	"github.com/entigolabs/entigo-infralib-agent/model"
+	"github.com/entigolabs/entigo-infralib-agent/service"
+	"github.com/entigolabs/entigo-infralib-agent/util"
+	"gopkg.in/yaml.v3"
+	"log"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func Run(ctx context.Context, flags *common.Flags) {
+	provider := service.GetCloudProvider(ctx, flags)
+	resources := provider.GetResources()
+	conf := service.GetRemoteConfig(nil, resources.GetCloudPrefix(), resources.GetBucket())
+	basePath := ""
+	if flags.Config != "" {
+		basePath = filepath.Dir(flags.Config) + "/"
+	}
+	existingFiles := getExistingFiles(flags.Config, conf, basePath)
+	if len(existingFiles) != 0 {
+		if !flags.Force {
+			log.Fatalf("Files already exist in config folder. Use force to overwrite. Files: %s", strings.Join(existingFiles, ", "))
+		} else {
+			log.Printf("Force flag set. Overwriting existing files: %s", strings.Join(existingFiles, ", "))
+		}
+	}
+	if flags.Force {
+		removeConfigFolder(basePath)
+	}
+	err := writeConfigFiles(conf, flags.Config, basePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Println("Config files written successfully")
+}
+
+func getExistingFiles(config string, conf model.Config, basePath string) []string {
+	files := make([]string, 0)
+	if config != "" {
+		files = append(files, config)
+	} else if util.FileExists(basePath, service.ConfigFile) {
+		files = append(files, service.ConfigFile)
+	}
+	if conf.Steps == nil {
+		return files
+	}
+	for _, step := range conf.Steps {
+		files = append(files, getModuleFiles(step, basePath)...)
+		if step.Files == nil {
+			continue
+		}
+		for _, file := range step.Files {
+			if util.FileExists(basePath, file.Name) {
+				files = append(files, file.Name)
+			}
+		}
+	}
+	return files
+}
+
+func getModuleFiles(step model.Step, basePath string) []string {
+	files := make([]string, 0)
+	if step.Modules == nil {
+		return files
+	}
+	for _, module := range step.Modules {
+		if module.InputsFile == "" {
+			continue
+		}
+		if util.FileExists(basePath, module.InputsFile) {
+			files = append(files, module.InputsFile)
+		}
+	}
+	return files
+}
+
+func removeConfigFolder(basePath string) {
+	fullPath := filepath.Join(basePath, "config")
+	err := os.RemoveAll(fullPath)
+	if err != nil {
+		log.Fatalf("Failed to delete folder %s: %v", fullPath, err)
+	}
+	slog.Debug(fmt.Sprintf("Deleted folder %s", fullPath))
+}
+
+func writeConfigFiles(conf model.Config, config string, basePath string) error {
+	bytes, err := yaml.Marshal(conf)
+	if err != nil {
+		log.Fatalf("Failed to marshal config: %s", err)
+	}
+	if config == "" {
+		config = filepath.Join(basePath, service.ConfigFile)
+	}
+	err = writeFile(config, bytes)
+	if err != nil {
+		return err
+	}
+	if conf.Steps == nil {
+		return nil
+	}
+	for _, step := range conf.Steps {
+		err = writeModuleFiles(step, basePath)
+		if err != nil {
+			return err
+		}
+		if step.Files == nil {
+			continue
+		}
+		for _, file := range step.Files {
+			err = writeFile(filepath.Join(basePath, file.Name), file.Content)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeModuleFiles(step model.Step, basePath string) error {
+	if step.Modules == nil {
+		return nil
+	}
+	for _, module := range step.Modules {
+		if module.InputsFile == "" {
+			continue
+		}
+		bytes, err := yaml.Marshal(module.Inputs)
+		if err != nil {
+			log.Fatalf("Failed to marshal module inputs: %s", err)
+		}
+		err = writeFile(basePath+module.InputsFile, bytes)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeFile(file string, content []byte) error {
+	path := filepath.Dir(file)
+	err := os.MkdirAll(path, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create directory %s: %v", path, err)
+	}
+	err = os.WriteFile(file, content, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write file %s: %v", file, err)
+	}
+	slog.Debug(fmt.Sprintf("Wrote file %s", file))
+	return nil
+}

--- a/commands/pull/pull.go
+++ b/commands/pull/pull.go
@@ -18,7 +18,7 @@ import (
 func Run(ctx context.Context, flags *common.Flags) {
 	provider := service.GetCloudProvider(ctx, flags)
 	resources := provider.GetResources()
-	conf := service.GetRemoteConfig(nil, resources.GetCloudPrefix(), resources.GetBucket())
+	conf := service.GetRemoteConfig(nil, resources.GetCloudPrefix(), resources.GetBucket(), false)
 	basePath := ""
 	if flags.Config != "" {
 		basePath = filepath.Dir(flags.Config) + "/"
@@ -43,7 +43,7 @@ func Run(ctx context.Context, flags *common.Flags) {
 
 func getExistingFiles(config string, conf model.Config, basePath string) []string {
 	files := make([]string, 0)
-	if config != "" {
+	if config != "" && util.FileExists("", config) {
 		files = append(files, config)
 	} else if util.FileExists(basePath, service.ConfigFile) {
 		files = append(files, service.ConfigFile)

--- a/commands/run/run.go
+++ b/commands/run/run.go
@@ -7,7 +7,6 @@ import (
 )
 
 func Run(ctx context.Context, flags *common.Flags) {
-	common.PrintVersion()
 	updater := service.NewUpdater(ctx, flags)
 	updater.Run()
 }

--- a/commands/update/update.go
+++ b/commands/update/update.go
@@ -7,7 +7,6 @@ import (
 )
 
 func Update(ctx context.Context, flags *common.Flags) {
-	common.PrintVersion()
 	updater := service.NewUpdater(ctx, flags)
 	updater.Update()
 }

--- a/common/enum.go
+++ b/common/enum.go
@@ -8,6 +8,7 @@ const (
 	DeleteCommand    Command = "delete"
 	UpdateCommand    Command = "update"
 	SACommand        Command = "service-account"
+	PullCommand      Command = "pull"
 )
 
 type LogLevel string

--- a/common/flags.go
+++ b/common/flags.go
@@ -16,6 +16,7 @@ type Flags struct {
 	Prefix        string
 	AllowParallel bool
 	GithubToken   string
+	Force         bool
 	Steps         cli.StringSlice
 	Pipeline      Pipeline
 	GCloud        GCloud

--- a/common/flags_validation.go
+++ b/common/flags_validation.go
@@ -13,9 +13,14 @@ func (f *Flags) validate(cmd Command) error {
 		fallthrough
 	case DeleteCommand:
 		fallthrough
-	case SACommand:
-		fallthrough
 	case BootstrapCommand:
+		fallthrough
+	case PullCommand:
+		if f.Config == "" && f.Prefix == "" {
+			return fmt.Errorf("config or prefix must be set")
+		}
+		fallthrough
+	case SACommand:
 		if f.GCloud.ProjectId != "" {
 			if f.GCloud.Location == "" || f.GCloud.Zone == "" {
 				return fmt.Errorf("gcloud location and zone must be set")

--- a/git/storage.go
+++ b/git/storage.go
@@ -1,0 +1,38 @@
+package git
+
+import (
+	"github.com/entigolabs/entigo-infralib-agent/model"
+	"github.com/entigolabs/entigo-infralib-agent/util"
+	"os"
+	"path/filepath"
+)
+
+type Storage interface {
+	GetFile(source string, path string, release string) ([]byte, error)
+}
+
+type storage struct {
+	github Github
+}
+
+func NewStorage(github Github) Storage {
+	return &storage{
+		github: github,
+	}
+}
+
+func (s *storage) GetFile(source string, path string, release string) ([]byte, error) {
+	if util.IsLocalSource(source) {
+		return readFile(source, path)
+	}
+	return s.github.GetRawFileContent(source, path, release)
+}
+
+func readFile(source string, path string) ([]byte, error) {
+	fullPath := filepath.Join(source, path)
+	file, err := os.ReadFile(fullPath)
+	if os.IsNotExist(err) {
+		return nil, model.NewFileNotFoundError(path)
+	}
+	return file, nil
+}

--- a/service/config.go
+++ b/service/config.go
@@ -17,8 +17,9 @@ import (
 const (
 	StableVersion = "stable"
 	IncludeFormat = "config/%s/include"
+	ConfigFile    = "config.yaml"
+	EntigoSource  = "github.com/entigolabs/entigo-infralib-release"
 
-	EntigoSource   = "github.com/entigolabs/entigo-infralib-release"
 	terraformCache = ".terraform"
 )
 
@@ -131,7 +132,7 @@ func PutConfig(bucket model.Bucket, config model.Config) {
 	if err != nil {
 		log.Fatalf("Failed to marshal config: %s", err)
 	}
-	err = bucket.PutFile("config.yaml", bytes)
+	err = bucket.PutFile(ConfigFile, bytes)
 	if err != nil {
 		log.Fatalf("Failed to put config: %s", err)
 	}
@@ -222,7 +223,7 @@ func GetRemoteConfig(ssm model.SSM, prefix string, bucket model.Bucket) model.Co
 }
 
 func getRemoteConfigFile(bucket model.Bucket) model.Config {
-	bytes, err := bucket.GetFile("config.yaml")
+	bytes, err := bucket.GetFile(ConfigFile)
 	if err != nil {
 		log.Fatalf("Failed to get config: %s", err)
 	}

--- a/service/delete.go
+++ b/service/delete.go
@@ -35,7 +35,7 @@ func NewDeleter(ctx context.Context, flags *common.Flags) Deleter {
 			resources: resources,
 		}
 	}
-	config := getConfig(resources.GetCloudPrefix(), flags.Config, resources.GetBucket())
+	config := getBaseConfig(resources.GetCloudPrefix(), flags.Config, resources.GetBucket())
 	ValidateConfig(config, nil)
 	return &deleter{
 		config:               config,
@@ -46,7 +46,7 @@ func NewDeleter(ctx context.Context, flags *common.Flags) Deleter {
 	}
 }
 
-func getConfig(prefix, configFile string, bucket model.Bucket) model.Config {
+func getBaseConfig(prefix, configFile string, bucket model.Bucket) model.Config {
 	var config model.Config
 	if configFile != "" {
 		config = getLocalConfigFile(configFile)

--- a/service/replace.go
+++ b/service/replace.go
@@ -409,6 +409,9 @@ func (u *updater) findStepModuleByType(moduleType string) (*model.Step, *model.M
 }
 
 func replaceConfigValues(ssm model.SSM, prefix string, config model.Config) model.Config {
+	if ssm == nil {
+		return config
+	}
 	steps := config.Steps
 	config.Steps = nil
 	config = replaceConfigRootValues(ssm, prefix, config)
@@ -430,11 +433,9 @@ func replaceConfigRootValues(ssm model.SSM, prefix string, config model.Config) 
 	if err != nil {
 		log.Fatalf("Failed to replace tags in config root, error: %v", err)
 	}
-	if ssm != nil {
-		modifiedConfigYaml, err = replaceConfigCustomTags(ssm, modifiedConfigYaml, matches)
-		if err != nil {
-			log.Fatalf("Failed to replace custom output tags in config root, error: %v", err)
-		}
+	modifiedConfigYaml, err = replaceConfigCustomTags(ssm, modifiedConfigYaml, matches)
+	if err != nil {
+		log.Fatalf("Failed to replace custom output tags in config root, error: %v", err)
 	}
 	err = yaml.Unmarshal([]byte(modifiedConfigYaml), &config)
 	if err != nil {

--- a/service/update.go
+++ b/service/update.go
@@ -56,7 +56,7 @@ type updater struct {
 func NewUpdater(ctx context.Context, flags *common.Flags) Updater {
 	provider := GetCloudProvider(ctx, flags)
 	resources := provider.SetupResources()
-	config := GetConfig(resources.GetSSM(), resources.GetCloudPrefix(), flags.Config, resources.GetBucket())
+	config := GetFullConfig(resources.GetSSM(), resources.GetCloudPrefix(), flags.Config, resources.GetBucket())
 	state := getLatestState(resources.GetBucket())
 	ValidateConfig(config, state)
 	ProcessConfig(&config, resources.GetProviderType())

--- a/util/util.go
+++ b/util/util.go
@@ -112,6 +112,28 @@ func IsClientModule(module model.Module) bool {
 	return strings.HasPrefix(module.Source, "git::") || strings.HasPrefix(module.Source, "git@")
 }
 
+func IsLocalSource(source string) bool {
+	return !strings.HasPrefix(source, "http:") && !strings.HasPrefix(source, "https:")
+}
+
+func PathExists(source, path string) bool {
+	fullPath := filepath.Join(source, path)
+	info, err := os.Stat(fullPath)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return info.IsDir()
+}
+
+func FileExists(source, path string) bool {
+	fullPath := filepath.Join(source, path)
+	info, err := os.Stat(fullPath)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
 func TarGzWrite(inDirPath string) ([]byte, error) {
 	buf := new(bytes.Buffer)
 	gw := gzip.NewWriter(buf)


### PR DESCRIPTION
Added pull command for pulling configuration files from S3/GCloud storage.

Config source url can now be a local path to a folder with modules and providers. Used for development with local pipeline execution type.

Added creating AWS service-linked role for the `autoscaling.amazonaws.com` service.